### PR TITLE
Add bank account validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.athento.nuxeo</groupId>
 	<artifactId>athento-nx-field-validator</artifactId>
-	<version>1.0</version>
+	<version>1.1</version>
 	<name>athento-nx-field-validator</name>
 	<description />
 	<distributionManagement>

--- a/src/main/java/org/athento/nuxeo/validator/FieldValidatorBean.java
+++ b/src/main/java/org/athento/nuxeo/validator/FieldValidatorBean.java
@@ -34,25 +34,6 @@ public class FieldValidatorBean implements Serializable {
 		return true;
 	}
 
-	public void validateText(FacesContext context, UIComponent component,
-			Object value) {
-		if (_log.isDebugEnabled()) {
-			_log.debug("Validating text: " + value);
-		}
-		String theValue = (String) value;
-		String expression = "^[a-zA-Z0-9]{0,30}$";
-		if (isValid(theValue, expression)) {
-			// do nothing as the given string is well-formed
-			return;
-		} else {
-			// display an error in the input form
-			FacesMessage message = new FacesMessage(
-					FacesMessage.SEVERITY_ERROR, ComponentUtils.translate(
-							context, "label.error.validator.text"), null);
-			throw new ValidatorException(message);
-		}
-	}
-
 	public void validateEmailAddress(FacesContext context,
 			UIComponent component, Object value) {
 		if (_log.isDebugEnabled()) {
@@ -167,6 +148,25 @@ public class FieldValidatorBean implements Serializable {
 					FacesMessage.SEVERITY_ERROR, ComponentUtils.translate(
 							context, "label.error.validator.homePhoneNumber"),
 					null);
+			throw new ValidatorException(message);
+		}
+	}
+
+	public void validateText(FacesContext context, UIComponent component,
+			Object value) {
+		if (_log.isDebugEnabled()) {
+			_log.debug("Validating text: " + value);
+		}
+		String theValue = (String) value;
+		String expression = "^[a-zA-Z0-9]{0,30}$";
+		if (isValid(theValue, expression)) {
+			// do nothing as the given string is well-formed
+			return;
+		} else {
+			// display an error in the input form
+			FacesMessage message = new FacesMessage(
+					FacesMessage.SEVERITY_ERROR, ComponentUtils.translate(
+							context, "label.error.validator.text"), null);
 			throw new ValidatorException(message);
 		}
 	}

--- a/src/main/java/org/athento/nuxeo/validator/FieldValidatorBean.java
+++ b/src/main/java/org/athento/nuxeo/validator/FieldValidatorBean.java
@@ -46,7 +46,6 @@ public class FieldValidatorBean implements Serializable {
 				"dcInputId");
 		String accountNumber = retrieveInputComponentValue_asString(component,
 				"accountNumberInputId");
-		
 		if (isValidBankAccountNumber(bankCode, branchCode, controlDigit, accountNumber)) {
 			// do nothing as the given string is well-formed
 			return;
@@ -58,7 +57,6 @@ public class FieldValidatorBean implements Serializable {
 							"label.error.validator.bank.account.number"), null);
 			throw new ValidatorException(message);
 		}
-
 	}
 
 	public void validateBankAccountNumber_allInOne(FacesContext context,

--- a/src/main/java/org/athento/nuxeo/validator/FieldValidatorBean.java
+++ b/src/main/java/org/athento/nuxeo/validator/FieldValidatorBean.java
@@ -4,11 +4,13 @@
 package org.athento.nuxeo.validator;
 
 import java.io.Serializable;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.faces.application.FacesMessage;
 import javax.faces.component.UIComponent;
+import javax.faces.component.UIInput;
 import javax.faces.context.FacesContext;
 import javax.faces.validator.ValidatorException;
 import javax.xml.bind.ValidationException;
@@ -32,6 +34,55 @@ public class FieldValidatorBean implements Serializable {
 			_log.debug("Accepting form");
 		}
 		return true;
+	}
+
+	public void validateBankAccountNumber_byParts(FacesContext context, UIComponent component,
+			Object value) {
+		String bankCode = retrieveInputComponentValue_asString(component,
+				"bankCodeInputId");
+		String branchCode = retrieveInputComponentValue_asString(component,
+				"branchCodeInputId");
+		String controlDigit = retrieveInputComponentValue_asString(component,
+				"dcInputId");
+		String accountNumber = retrieveInputComponentValue_asString(component,
+				"accountNumberInputId");
+		
+		if (isValidBankAccountNumber(bankCode, branchCode, controlDigit, accountNumber)) {
+			// do nothing as the given string is well-formed
+			return;
+		} else {
+			// display an error in the input form
+			FacesMessage message = new FacesMessage(
+					FacesMessage.SEVERITY_ERROR, ComponentUtils.translate(
+							context,
+							"label.error.validator.bank.account.number"), null);
+			throw new ValidatorException(message);
+		}
+
+	}
+
+	public void validateBankAccountNumber_allInOne(FacesContext context,
+			UIComponent component, Object value) {
+		if (_log.isDebugEnabled()) {
+			_log.debug("Validating bank account: " + value);
+		}
+		String ban = (String) value;
+		String bankCode = ban.substring(0, 4);
+		String branchCode = ban.substring(4, 8);
+		String controlDigit = ban.substring(8, 10);
+		String accountNumber = ban.substring(10, 20);
+
+		if (isValidBankAccountNumber(bankCode, branchCode, controlDigit, accountNumber)) {
+			// do nothing as the given string is well-formed
+			return;
+		} else {
+			// display an error in the input form
+			FacesMessage message = new FacesMessage(
+					FacesMessage.SEVERITY_ERROR, ComponentUtils.translate(
+							context,
+							"label.error.validator.bank.account.number"), null);
+			throw new ValidatorException(message);
+		}
 	}
 
 	public void validateEmailAddress(FacesContext context,
@@ -171,6 +222,15 @@ public class FieldValidatorBean implements Serializable {
 		}
 	}
 
+	private String getControlDigit(String bankCode, String branchCode,
+			String accountNumber) {
+		String rsum1;
+		String rsum2;
+		rsum1 = mod11("00" + bankCode + branchCode);
+		rsum2 = mod11(accountNumber);
+		return rsum1 + rsum2;
+	}
+
 	private boolean isValid(String value, String regexp) {
 		if (_log.isDebugEnabled()) {
 			_log.debug("Validating [" + value + "] against regexp [" + regexp
@@ -207,6 +267,40 @@ public class FieldValidatorBean implements Serializable {
 			}
 			return false;
 		}
+	}
+
+	private String mod11(String str) {
+		int[] digits = new int[] { 1, 2, 4, 8, 5, 10, 9, 7, 3, 6 };
+		int sum = 0;
+		for (int i = 0; i != 10; i++) {
+			sum += (Integer.parseInt(str.substring(i, i + 1)) * digits[i]);
+		}
+		sum = 11 - sum % 11;
+		if (sum == 11)
+			sum = 0;
+		if (sum == 10)
+			sum = 1;
+		return String.valueOf(sum);
+	}
+
+	private Object retrieveInputComponentValue(UIComponent anchor,
+			String componentId) {
+		Map attributes = anchor.getAttributes();
+		String inputId = (String) attributes.get(componentId);
+		UIInput component = (UIInput) anchor.findComponent(inputId);
+		return component.getLocalValue();
+	}
+
+	private String retrieveInputComponentValue_asString(UIComponent anchor,
+			String componentId) {
+		Object o = retrieveInputComponentValue(anchor, componentId);
+		return (o!=null?o.toString():null);
+	}
+
+	private boolean isValidBankAccountNumber(
+		String bankCode, String branchCode, String controlDigit, String accountNumber) {
+		String cd = getControlDigit(bankCode, branchCode, accountNumber);
+		return controlDigit.equals(cd);
 	}
 
 	private static Log _log = LogFactory.getLog(FieldValidatorBean.class);

--- a/src/main/resources/OSGI-INF/deployment-fragment.xml
+++ b/src/main/resources/OSGI-INF/deployment-fragment.xml
@@ -12,14 +12,20 @@
 		<delete path="${bundle.fileName}.tmp" />
 		<unzip from="${bundle.fileName}" to="${bundle.fileName}.tmp" />
 		<copy from="${bundle.fileName}.tmp/web/nuxeo.war" to="/" />
-		<delete path="${bundle.fileName}.tmp" />
 		<unzip from="${bundle.fileName}" to="${bundle.fileName}.tmp"
 			prefix="OSGI-INF/l10n">
 			<include>OSGI-INF/l10n/*-messages.properties</include>
+			<include>OSGI-INF/l10n/*-messages*.properties</include>
 		</unzip>
 		<append from="${bundle.fileName}.tmp" pattern="*-messages.properties"
 			to="nuxeo.war/WEB-INF/classes/messages.properties" addNewLine="true" />
-		<delete path="${bundle.fileName}.tmp" />
+		<append from="${bundle.fileName}.tmp" pattern="*-messages_es_ES.properties"
+			to="nuxeo.war/WEB-INF/classes/messages_es_ES.properties" addNewLine="true" />
+		<append from="${bundle.fileName}.tmp/OSGI-INF/l10n/org.athento.nuxeo.validator.fieldValidatorBean-messages_es_ES.properties"
+			to="nuxeo.war/WEB-INF/classes/messages_es.properties" addNewLine="true" />
 	</install>
+
+
+
 
 </fragment>

--- a/src/main/resources/OSGI-INF/l10n/org.athento.nuxeo.validator.fieldValidatorBean-messages.properties
+++ b/src/main/resources/OSGI-INF/l10n/org.athento.nuxeo.validator.fieldValidatorBean-messages.properties
@@ -1,4 +1,5 @@
 label.org.athento.nuxeo.validator.fieldValidatorBean=fieldValidator
+label.error.validator.bank.account.number=Please, check bank account data. 
 label.error.validator.email=Please, type a correct email (i.e. someuser@someserver.com)
 label.error.validator.homePhoneNumber=Please, type a correct home phone number (must begin with 8 or 9 and have 9 digits) 
 label.error.validator.mobilePhoneNumber=Please, type a correct home phone number (must begin with 6 or 7 and have 9 digits)

--- a/src/main/resources/OSGI-INF/l10n/org.athento.nuxeo.validator.fieldValidatorBean-messages_es_ES.properties
+++ b/src/main/resources/OSGI-INF/l10n/org.athento.nuxeo.validator.fieldValidatorBean-messages_es_ES.properties
@@ -6,4 +6,3 @@ label.error.validator.mobilePhoneNumber=Por favor, revise el formato del teléfon
 label.error.validator.nifFormat=Por favor, revise el formato del NIF/NIE (debe contener 8 cifras y una letra)
 label.error.validator.nifLetter=Por favor, revise la letra correspondiente al NIF/NIE introducido
 label.error.validator.text=Por favor, revise el texto introducido.
-

--- a/src/main/resources/OSGI-INF/l10n/org.athento.nuxeo.validator.fieldValidatorBean-messages_es_ES.properties
+++ b/src/main/resources/OSGI-INF/l10n/org.athento.nuxeo.validator.fieldValidatorBean-messages_es_ES.properties
@@ -1,7 +1,9 @@
 label.org.athento.nuxeo.validator.fieldValidatorBean=fieldValidator
+label.error.validator.bank.account.number=Por favor, revise los datos de la cuenta bancaria.
 label.error.validator.email=Por favor, revise el formato del correo electrónico (por ejemplo: unusuario@unservidor.com)
 label.error.validator.homePhoneNumber=Por favor, revise el formato del teléfono (debe comenzar por 8 o 9 y contener 9 cifras) 
 label.error.validator.mobilePhoneNumber=Por favor, revise el formato del teléfono (debe comenzar por 6 o 7 y contener 9 cifras)
 label.error.validator.nifFormat=Por favor, revise el formato del NIF/NIE (debe contener 8 cifras y una letra)
 label.error.validator.nifLetter=Por favor, revise la letra correspondiente al NIF/NIE introducido
 label.error.validator.text=Por favor, revise el texto introducido.
+


### PR DESCRIPTION
Two methods are provided:

`validateBankAccountNumber_byParts`

To use it, define a widget of type "template" and use a template as this one:

`<div xmlns:f="http://java.sun.com/jsf/core"
    xmlns:h="http://java.sun.com/jsf/html"
    xmlns:c="http://java.sun.com/jstl/core">
    <c:if test="#{widget.mode == 'edit'}">
        <h:inputHidden value="needed"
            validator="#{bFieldValidator.validateBankAccountNumber_byParts}"
            id="#{widget.id}">
            <f:attribute name="bankCodeInputId"
                value="#{layout.widgetMap['BankCode'].id}" />
            <f:attribute name="branchCodeInputId"
                value="#{layout.widgetMap['BranchCode'].id}" />
            <f:attribute name="dcInputId"
                value="#{layout.widgetMap['ControlDigitCode'].id}" />
            <f:attribute name="accountNumberInputId"
                value="#{layout.widgetMap['AccountNumber'].id}" />
        </h:inputHidden>
        <h:message for="#{widget.id}" styleClass="errorMessage" />
    </c:if>
</div>`

Where BankCode, BranchCode, ControlDigitCode and AccountNumber are widget names of type text

`validateBankAccountNumber_allInOne`

The second one, just validates as any other field
